### PR TITLE
Adding PORT env var and updating jQuery version

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ var connect = require('connect'),
 exports.start = function(directory){
 
   // config
-  var port = 3000;
+  var port = process.env.PORT || 3000;
   var public_dir = path.join(directory, 'public');
 
   var app = connect().use(connect.static(public_dir));

--- a/templates/new/assets/js/main.coffee
+++ b/templates/new/assets/js/main.coffee
@@ -2,7 +2,7 @@
 
 # Add scripts to load to this array. These can be loaded remotely like jquery
 # is below, or can use file paths, like 'vendor/underscore'
-js = ["http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"]
+js = ["http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"]
 
 # this will fire once the required scripts have been loaded
 require js, ->


### PR DESCRIPTION
Adding PORT environment variable to 'watch' and updating jQuery version to latest (1.8.3)

Watch can now be run with

`PORT=3001 roots watch`
