### PR TITLE
use the global compress flag for jade and stylus compiling

### DIFF
--- a/lib/compilers/core/jade.js
+++ b/lib/compilers/core/jade.js
@@ -8,8 +8,8 @@ exports.compile = function(files, Helper, cb){
   files.forEach(function(file){
     try {
       var helper = new Helper(file)
-      var page = jade.compile(helper.file_contents, { pretty: true, filename: helper.file_path });
-      var template = jade.compile(helper.layout_contents, { pretty: true, filename: helper.layout_path })
+      var page = jade.compile(helper.file_contents, { pretty: !global.options.compress, filename: helper.file_path });
+      var template = jade.compile(helper.layout_contents, { pretty: !global.options.compress, filename: helper.layout_path })
       var rendered_template = template( helper.locals({ yield: page(helper.locals()) }) )
       helper.write(rendered_template)
     } catch(err) {

--- a/lib/compilers/core/styl.js
+++ b/lib/compilers/core/styl.js
@@ -12,6 +12,8 @@ exports.compile = function(files, Helper, cb){
     stylus(helper.file_contents)
       // for more accurate error reporting
       .set('filename', file)
+      // for compression
+      .set('compress', global.options.compress)
       // for imports to work
       .include(require('path').dirname(helper.file_path))
       // load roots css library
@@ -21,7 +23,6 @@ exports.compile = function(files, Helper, cb){
         if (err) { error = err }
         helper.write( compiled_css )
       });
-
   });
   cb(error);
 }


### PR DESCRIPTION
I added stuff for jade and stylus

but we should think about adding this for javascript 

https://github.com/mishoo/UglifyJS2

this PR is for the first part of this really https://github.com/jenius/roots/issues/33
