### PR TITLE
switch from fresher to update-notifier

### DIFF
--- a/bin/roots
+++ b/bin/roots
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+// check for a new version
+var notifier = require('update-notifier')({packagePath: '../package.json'});
+if (notifier.update){
+  notifier.notify();
+}
+
 var argv = process.argv.slice(2),
     commands = require('../lib/commands'),
     configure_options = require('../lib/utils/configure_options');

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,8 +1,6 @@
 var path = require('path'),
     shell = require('shelljs'),
     run = require('child_process').exec,
-    colors = require('colors'),
-    fresher = require('fresher'),
     current_directory = path.normalize(process.cwd());
 
 var _new = function(commands){
@@ -10,25 +8,6 @@ var _new = function(commands){
   if (typeof commands[0] === "undefined") {
     return console.error('make sure to pass a name for your project!'.red);
   }
-
-  // 
-  // check for a new version
-  // 
-
-  // if the request takes more than 2.5 seconds to come back, forget it
-  var update_checked = false;
-  var guard = setTimeout(function(){ !update_checked && process.exit(); }, 2500)
-
-  // check against npm
-  var update = fresher('roots', path.join(__dirname, '../../package.json'), function(err, update){
-    clearTimeout(guard)
-    if (update){
-      update_checked = true;
-      console.log('a new version of roots is out'.yellow);
-      console.log('update with ' + 'npm install roots -g'.bold);
-      console.log('');
-    }
-  });
 
   switch (commands[1]){
     case '--basic':

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "js-yaml": "2.1.x",
     "semver": "1.1.x",
     "faye-websocket": "0.6.x",
-    "fresher": "0.0.x"
+    "update-notifier": "~0.1.3"
   },
   "devDependencies": {
     "mocha": "latest",


### PR DESCRIPTION
and move update notifications to `./bin/roots` because update checking is now daily...
checking on a daily basis seems better than doing it whenever `roots new` is run.
