### PR TITLE
Do not attempt to symlink on Windows (symlinking requires Admin privileges)

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -89,7 +89,7 @@ Compiler.prototype.copy = function(file, cb){
     fs.writeFileSync(destination, write_content);
   } else {
     // symlink in development mode
-    if (this.mode() === 'dev') {
+    if (this.mode() === 'dev' && process.platform !== 'win32') {
       fs.existsSync(destination) || fs.symlinkSync(file, destination);
     } else {
       shell.cp('-f', file, destination);


### PR DESCRIPTION
Related to my comment on #150.

I'm not sure if you'd rather require Windows users to run roots as Admin, or for roots to automatically detect whether or not it's being run as Admin, or for roots to use junction points for directories.
