### PR TITLE
Start adding analytics

### DIFF
--- a/lib/analytics.coffee
+++ b/lib/analytics.coffee
@@ -1,0 +1,31 @@
+Keen = require 'keen.io'
+roots = require './index'
+global_config = require './global_config'
+
+class Analytics
+
+  constructor: ->
+    @keen = Keen.configure
+      projectId: '5252fe3d36bf5a4f54000008'
+      writeKey: 'd4dff32fa0e23516cf4828d2a71219255efd581f8ab3c1a0cc7081e8b1db62825f83b0b5f9ec6417fd23fb877d082d1d5ce238ddc46d048b8ba6608557e87904a475f2a930e4903fc9872323fc120a4859dfb06919d9052e3b676e863a8f6332c21c5cb58be186457398780475dc62a5'
+
+  disable: ->
+    global_config.modify('analytics', 'false')
+
+  enable: ->
+    global_config.modify('analytics', 'true')
+
+  disabled: ->
+    global_config.get().analytics || false
+
+  track_command: (name, args = 'none') ->
+    if @disabled() then return false
+    @keen.addEvent 'commands', { name: name, args: args }, (err, res) ->
+      if err then roots.print.debug(err)
+
+  track_error: (error) ->
+    if @disabled() then return false
+    @keen.trackEvent 'errors', { message: error }, (err, res) ->
+      if err then roots.print.debug(err)
+
+module.exports = new Analytics

--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -1,9 +1,11 @@
 var roots = require('../index'),
-    shell = require('shelljs');
+    shell = require('shelljs'),
+    analytics = require('../analytics');
 
 var _clean = function(){
   roots.print.log('cleaning...', 'grey');
   shell.rm('-rf', roots.project.path('public'));
+  analytics.track_command('clean')
 };
 
 module.exports = { execute: _clean };

--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -1,6 +1,7 @@
 var roots = require('../index'),
     path = require('path'),
-    shell = require('shelljs');
+    shell = require('shelljs'),
+    analytics = require('../analytics');
 
 var _compile = function(args){
   shell.rm('-rf', roots.project.path('public'));
@@ -12,6 +13,8 @@ var _compile = function(args){
   if (roots.project.conf('compress')) {
     roots.print.log('\nminifying & compressing...\n', 'grey');
   }
+
+  analytics.track_command('compile', args._);
 };
 
 module.exports = { execute: _compile, needs_config: true };

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -4,7 +4,8 @@ var shell = require('shelljs'),
     path = require('path'),
     colors = require('colors'),
     roots = require('../index'),
-    Deployer = require('../deployer');
+    Deployer = require('../deployer'),
+    analytics = require('../analytics');
 
 var _deploy = function(args){
 
@@ -47,6 +48,9 @@ var _deploy = function(args){
     if (err) return roots.print.error(err);
     roots.print.log('done!', 'green');
   });
+
+  analytics.track_command('deploy', args._);
+
 };
 
 module.exports = { execute: _deploy, needs_config: true };

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -1,5 +1,6 @@
 var colors = require('colors'),
-    roots = require('../index');
+    roots = require('../index'),
+    analytics = require('../analytics');
 
 var _help = function(){
   roots.print.log(
@@ -20,6 +21,7 @@ var _help = function(){
     "- " + "plugin install `username/repo`: ".bold + "installs a plugin from a github repo\n\n" +
     "...and by all means check out " + "http://roots.cx".green + " for more help!\n\n"
   );
+  analytics.track_command('help');
 };
 
 module.exports = { execute: _help };

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -4,7 +4,8 @@ var path = require('path'),
     run = require('child_process').exec,
     roots = require('../index'),
     config = require('../global_config'),
-    colors = require('colors');
+    colors = require('colors'),
+    analytics = require('../analytics');
 
 var _new = function(args){
   if (args._.length < 2) {
@@ -34,6 +35,9 @@ var _new = function(args){
       roots.print.log('Check out http://git-scm.com/ for a quick and easy download\n', 'yellow');
     }
   });
+
+  // track
+  analytics.track_command('new', args._)
 
   // done!
   roots.print.log('\nnew project created at /' + name + '\n', 'green');

--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -1,10 +1,13 @@
 var path = require('path'),
-    config = require('../global_config');
+    config = require('../global_config'),
+    analytics = require('../analytics');
 
 var _pkg = function(args){
 
   var pkg_mgr = require(path.join('../package_managers', config.get().package_manager));
   pkg_mgr(args._.slice(1));
+
+  analytics.track_command('pkg', args._);
 
 };
 

--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -3,7 +3,8 @@ var fs = require('fs'),
     path = require('path'),
     run = require('child_process').exec,
     colors = require('colors'),
-    roots = require('../index');
+    roots = require('../index'),
+    analytics = require('../analytics');
 
 var _plugin = function(args){
 
@@ -43,6 +44,8 @@ var _plugin = function(args){
     roots.print.log("- " + "generate: ".bold + "generate a coffeescript plugin template. `--js` for javascript\n");
     roots.print.log("- " + "install <username/repo>: ".bold + "install a plugin from a github repo\n\n");
   }
+
+  analytics.track_command('plugin', args._);
 
 };
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,9 +1,11 @@
 var path = require('path'),
     server = require('../server'),
-    roots = require('../index');
+    roots = require('../index'),
+    analytics = require('../analytics');
 
 var _serve = function(){
   server.start(roots.project.rootDir);
+  analytics.track_command('serve');
 };
 
 module.exports = { execute: _serve };

--- a/lib/commands/template.js
+++ b/lib/commands/template.js
@@ -3,7 +3,8 @@ var config = require('../global_config'),
     path = require('path'),
     fs = require('fs'),
     shell = require('shelljs'),
-    colors = require('colors');
+    colors = require('colors'),
+    analytics = require('../analytics');
 
 var _template = function(args){
   var cmd = args._[1];
@@ -26,6 +27,7 @@ var _template = function(args){
     default:
       usage();
   }
+  analytics.track_command('template', args._);
 };
 
 module.exports = { execute: _template };

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -1,10 +1,12 @@
 var fs = require('fs'),
     roots = require('../index'),
-    path = require('path');
+    path = require('path'),
+    analytics = require('../analytics');
 
 var _version = function(){
   var version = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'))).version;
   roots.print.log(version);
+  analytics.track_command('version');
 };
 
 module.exports = { execute: _version };

--- a/lib/commands/watch.js
+++ b/lib/commands/watch.js
@@ -6,7 +6,8 @@ var path = require('path'),
     yaml_parser = require('../utils/yaml_parser'),
     watcher = require('../watcher'),
     roots = require('../index'),
-    colors = require('colors');
+    colors = require('colors'),
+    analytics = require('../analytics');
 
 roots.server = require('../server');
 _.bindAll(roots.print, 'reload');
@@ -58,6 +59,8 @@ var _watch = function(){
       }
     }
   }
+
+  analytics.track_command('watch');
 };
 
 module.exports = { execute: _watch, needs_config: true };

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var colors = require('colors'),
     _ = require('underscore'),
     readdirp = require('readdirp'),
     minimatch = require('minimatch'),
-    Q = require('q');
+    Q = require('q'),
+    analytics = require('./analytics');
 
 var Project = require('./project');
 var project = exports.project = new Project(process.cwd());
@@ -28,6 +29,7 @@ _.bindAll(compiler, 'compile', 'copy', 'finish');
 
 compiler.on('error', function(err){
   print.error(err);
+  analytics.track_error(err);
   compiler.finish();
 });
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "prettyjson": "0.8.x",
     "autoprefixer": "0.8.x",
     "node-sass": "~0.6.6",
-    "express": "3.3.x"
+    "express": "3.3.x",
+    "keen.io": "0.0.3"
   },
   "devDependencies": {
     "mocha": "latest",

--- a/templates/global_config/default.json
+++ b/templates/global_config/default.json
@@ -8,5 +8,6 @@
     "ejs": "ejs",
     "express": "express",
     "min": "min"
-  }
+  },
+  "analytics": "true"
 }


### PR DESCRIPTION
Getting started with adding some analytics, using [keen.io](http://keen.io), as discussed in #239. Pushed through a couple sample events and it was working. Still need:
- [ ] add tests
- [ ] ability to enable or disable through command line
- [ ] ensure that if analytics isn't present in global config, it's created
- [ ] add clear instructions to the readme on how to disable if desired
- [ ] should we add [sentry's global error handler](https://github.com/mattrobenolt/raven-node#catching-global-errors)?
- [ ] make it faster, this slows down commands by ~1s which is no good
- [ ] make sure events are not triggered by tests (environment variables?)
