### PR TITLE
Allow a --no-open argument when running roots watch

### DIFF
--- a/lib/commands/watch.js
+++ b/lib/commands/watch.js
@@ -11,9 +11,9 @@ var path = require('path'),
 roots.server = require('../server');
 _.bindAll(roots.print, 'reload');
 
-var _watch = function(){
-
+var _watch = function(args){
   roots.print.compiling();
+  if (args.open == false) roots.project.open = false
 
   // compile once and run the local server when ready
   roots.project.mode = 'dev';

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -67,6 +67,12 @@ class Project extends EventEmitter
   livereloadEnabled: true
 
   ###*
+   * If watch should open browser
+   * @type {Boolean}
+  ###
+  open: true
+
+  ###*
    * [layouts description]
    * @type {Object}
   ###

--- a/lib/server.js
+++ b/lib/server.js
@@ -95,6 +95,6 @@ exports.start = function(serve_dir){
   if (roots.project.conf('debug')) app.use(connect.logger('dev'));
 
   var server = exports.server = http.createServer(app).listen(port);
-  open('http://localhost:' + port);
+  if (roots.project.conf('open') === true) open('http://localhost:' + port);
   roots.print.log('server started on port ' + port, 'green');
 };


### PR DESCRIPTION
I accidentally closed the last PR by deleting my remote branch. But here is the commit.
