### PR TITLE
Detect error exit on compile

### DIFF
--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -6,7 +6,11 @@ var _compile = function(args){
   if (args['compress'] == undefined) { global.options.compress = true; }
 
   shell.rm('-rf', path.join(process.cwd(), options.output_folder));
-  roots.compile_project(process.cwd(), function(){});
+  roots.compile_project(process.cwd(), function(){
+    if(global.options.error === true){
+        process.exit(1);
+    }
+  });
 
   args['compress'] == undefined && process.stdout.write('\nminifying & compressing...\n'.grey);
 };


### PR DESCRIPTION
This exits with a non-zero status on detecting an error (which is set by
the add_error_messages utility)

This is to resolve #279
