### PR TITLE
Return an exit code on error

### DIFF
--- a/bin/roots
+++ b/bin/roots
@@ -14,6 +14,10 @@ var argv = process.argv.slice(2),
     configure_options = require('../lib/config_parser'),
     commands = require('../lib/commands');
 
+var errback = function(err){
+  process.exit(1);
+}
+
 if (args._.length < 1 && !args.version) {
   commands.help.execute();
 } else {
@@ -22,8 +26,8 @@ if (args._.length < 1 && !args.version) {
   if (typeof current_command == "undefined") return commands.help.execute();
 
   if (current_command.needs_config) {
-    configure_options(args, function(){ current_command.execute(args); });
+    configure_options(args, function(){ current_command.execute(args, function(){}, errback); });
   } else {
-    current_command.execute(args);
+    current_command.execute(args, function(){}, errback);
   }
 }

--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -2,12 +2,12 @@ var roots = require('../index'),
     path = require('path'),
     shell = require('shelljs');
 
-var _compile = function(args){
+var _compile = function(args, done, errback){
   shell.rm('-rf', roots.project.path('public'));
 
   if (args.compress == false) roots.project.compress = false;
 
-  roots.compile_project(roots.project.rootDir, function(){});
+  roots.compile_project(roots.project.rootDir, done, errback);
 
   if (roots.project.conf('compress')) {
     roots.print.log('\nminifying & compressing...\n', 'grey');

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,13 @@ compiler.on('error', function(err){
 // @api public
 // Given a root (folder or file), compile with roots and output to /public
 
-exports.compile_project = function(root, done){
+exports.compile_project = function(root, done, errback){
 
   compiler.once('finished', done);
+
+  if (typeof errback !=='undefined') {
+    compiler.on('error', errback);
+  }
 
   fn.call(analyze, root)
   .then(function(ast){ return fn.lift(create_folders, ast)() })


### PR DESCRIPTION
This allows an errback to be optionally passed into compile_project. The
roots binary then takes advantage of this functionality to pass in an exit
handler. I was able to test this, but not as thoroughly as I liked,
because evidently our marketing project in its current form doesn't work
with the transformers branch.

Note that this is based on the transformers branch. I haven't been keeping track of the status of your branches, so let me know if development has moved elsewhere.
