### PR TITLE
Return an exit code on error

### DIFF
--- a/bin/roots
+++ b/bin/roots
@@ -14,6 +14,10 @@ var argv = process.argv.slice(2),
     configure_options = require('../lib/config_parser'),
     commands = require('../lib/commands');
 
+var errback = function(err){
+  process.exit(1);
+}
+
 if (args._.length < 1 && !args.version) {
   commands.help.execute();
 } else {
@@ -22,8 +26,8 @@ if (args._.length < 1 && !args.version) {
   if (typeof current_command == "undefined") return commands.help.execute();
 
   if (current_command.needs_config) {
-    configure_options(args, function(){ current_command.execute(args); });
+    configure_options(args, function(){ current_command.execute(args, function(){}, errback); });
   } else {
-    current_command.execute(args);
+    current_command.execute(args, function(){}, errback);
   }
 }

--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -2,12 +2,12 @@ var roots = require('../index'),
     path = require('path'),
     shell = require('shelljs');
 
-var _compile = function(args){
+var _compile = function(args, done, errback){
   shell.rm('-rf', roots.project.path('public'));
 
   if (args.compress == false) roots.project.compress = false;
 
-  roots.compile_project(roots.project.rootDir, function(){});
+  roots.compile_project(roots.project.rootDir, done, errback);
 
   if (roots.project.conf('compress')) {
     roots.print.log('\nminifying & compressing...\n', 'grey');

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,13 @@ compiler.on('error', function(err){
 // @api public
 // Given a root (folder or file), compile with roots and output to /public
 
-exports.compile_project = function(root, done){
+exports.compile_project = function(root, done, errback){
 
   compiler.once('finished', done);
+
+  if (typeof errback !=='undefined') {
+    compiler.on('error', errback);
+  }
 
   fn.call(analyze, root)
   .then(function(ast){ return fn.lift(create_folders, ast)() })

--- a/test/basic_with_error/app.coffee
+++ b/test/basic_with_error/app.coffee
@@ -1,0 +1,11 @@
+# roots v2.0.0
+
+ignore_files: ['_*', 'readme*', '.git', '.gitignore', '.DS_Store']
+
+layouts:
+  default: 'layout.jade'
+
+locals:
+  title: 'Welcome to Roots!'
+  title_with_markup: ->
+    "<h1 class='title'>Welcome to Roots!</h1>"

--- a/test/basic_with_error/views/index.jade
+++ b/test/basic_with_error/views/index.jade
@@ -1,0 +1,1 @@
+nothing

--- a/test/basic_with_error/views/layout.jade
+++ b/test/basic_with_error/views/layout.jade
@@ -1,0 +1,15 @@
+!!!
+html
+  head
+    meta(charset='utf8')
+    meta(http-equiv='X-UA-Compatible', content='IE=edge, chrome=1')
+    meta(name='description', content='description of your site')
+    meta(name='author', content= "author of the site")
+
+    title welcome to roots!
+    
+  body
+    != content
+    != foo.bar.baz
+
+  //- add other scripts through require.js, not here

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -33,7 +33,9 @@ describe 'command', ->
     before (done) ->
       @root = path.join(root, 'basic')
       @output = path.join(@root, 'public')
-      run_in_dir(@root, 'compile', done)
+      run_in_dir @root, 'compile', (err, stdout, stderr) ->
+        (err?).should.equal(false)
+        done()
 
     it 'should compile files to /public', ->
       should.exist(@output, [
@@ -55,6 +57,18 @@ describe 'command', ->
       css_content.should.not.match /\n/
 
     after -> remove(path.join(@root, 'public'))
+
+  describe 'compile with errors', ->
+    before ->
+      @basic_with_error_root = path.join root, 'basic_with_error'
+
+    it 'should give an exit code when compile has an error', (done) ->
+      run_in_dir @basic_with_error_root, 'compile', (err, stdout, stderr) ->
+        (err?).should.equal(true)
+        err.code.should.equal(1)
+        done()
+
+    after -> remove(path.join(@basic_with_error_root, 'public'))
 
   describe 'plugin', ->
 


### PR DESCRIPTION
This allows an errback to be optionally passed into compile_project. The
roots binary then takes advantage of this functionality to pass in an exit
handler. Tests modified to check for both the success and failure case.
