### PR TITLE
correct path in generator log

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -37,7 +37,7 @@ var _new = function(args){
 
   // done!
   var tmpl_name = template_name || config.get('default_template');
-  roots.print.log('\nnew project created at /' + name, 'green');
+  roots.print.log('\nnew project created at ./' + name, 'green');
   roots.print.log('(using ' + tmpl_name + ' template)\n', 'grey')
 };
 


### PR DESCRIPTION
The current generator output is scary: it looks like it is writing to the root directory.

```
$ roots new example
new project created at /example
(using default template)
```

Shouldn't this be a relative path, such as `./example`?
