### PR TITLE
[fix] catch template precompile errors

### DIFF
--- a/test/precompile_error/app.coffee
+++ b/test/precompile_error/app.coffee
@@ -1,0 +1,2 @@
+ignore_files: ['_*']
+templates: 'templates'

--- a/test/precompile_error/templates/sample.jade
+++ b/test/precompile_error/templates/sample.jade
@@ -1,0 +1,2 @@
+
+  span wait an hourn zan

--- a/test/precompiled_templates.coffee
+++ b/test/precompiled_templates.coffee
@@ -17,6 +17,17 @@ remove = (test_path) ->
 run_in_dir = (dir, cmd, cb) ->
   run("cd \"#{dir}\"; #{path.join(path.relative(dir, __dirname), '../bin/roots')} #{cmd}", cb)
 
+describe 'precompiled template errors', ->
+  before (done) ->
+    @root = path.join(root, 'precompile_error')
+    @output = path.join(@root, 'public')
+    done()
+
+  it 'notifies you if theres an error', (done) ->
+    run_in_dir @root, 'compile --no-compress', (err, out, stderr) ->
+      stderr.should.match /ERROR/
+      done()
+
 describe 'precompiled templates', ->
 
   before (done) ->


### PR DESCRIPTION
Fixes a race condition with the precompiler where we were not returning
a promise, and thus it was continuing down the compile chain while files
were still being compiled

This also fixes the issue of the roots watch command hard exiting when
an error occured while compiling the jade

fixes #361
