### PR TITLE
Properly display errors that are not 'Errors'

### DIFF
--- a/lib/terminal_printer.coffee
+++ b/lib/terminal_printer.coffee
@@ -21,6 +21,11 @@ module.exports = class TerminalPrinter
     @log text, color
 
   error: (err) =>
+    message = @normalize_error err
+    console.log '\u0007' # bell sound
+    console.error '\n\n------------ ERROR ------------\n\n'.red + message + '\n'
+
+  normalize_error: (err) ->
     if err instanceof Error
       message = err.stack
     else if typeof err is 'string'
@@ -29,9 +34,7 @@ module.exports = class TerminalPrinter
       message = err.toString()
       if message is '[object Object]'
         message = JSON.stringify err
-
-    console.log '\u0007' # bell sound
-    console.error '\n\n------------ ERROR ------------\n\n'.red + message + '\n'
+    message
 
   compiling: ->
     process.stdout.write('compiling... '.grey)


### PR DESCRIPTION
This is was initially brought up to fix a problem with YAML errors
being reported as 'undefined'. It should now show the result of the
object's toString, or the object stringified if the toString looks
unhelpful.

This is issue #369. I remember this giving me a headache as well when I first tried the tutorials but I forgot to do anything about it. Another side-note, I changed it a little so that strings aren't converted into Errors any more -- didn't seem that useful since that stack trace didn't go back to before the emission of the error event. Let me know if that's a problem!
