### PR TITLE
Special layout files now work (Fixed #308)

### DIFF
--- a/lib/extensions/layouts.coffee
+++ b/lib/extensions/layouts.coffee
@@ -68,7 +68,10 @@ class LayoutsExtension
     rel_file = path.relative(roots.project.path('views'), fh.path)
 
     # if there's a custom override, use that instead
-    layout = roots.project.layouts[key] for key of roots.project.layouts if key is rel_file
+    for key of roots.project.layouts
+      if key is rel_file
+        layout = roots.project.layouts[key]
+        break
 
     # no match
     if not layout? then return false


### PR DESCRIPTION
Layout overrides didn't previously work (Issue #308).
An alternate solution would be
```coffeescript
layout = roots.projects.layouts[rel_file] or layout
```