### PR TITLE
Fix for "could not create work tree dir" during project creation on Windows machines

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -8,7 +8,8 @@ var path = require('path'),
     osenv = require('osenv'),
     run = require('child_process').exec,
     roots = require('../index'),
-    config = require('../global_config');
+    config = require('../global_config'),
+    mkdirp = require('mkdirp');
 
 var _new = function(args){
   if (args._.length < 2) {
@@ -38,7 +39,7 @@ var _new = function(args){
   // done!
   var tmpl_name = template_name || config.get('default_template');
   roots.print.log('\nnew project created at ./' + name, 'green');
-  roots.print.log('(using ' + tmpl_name + ' template)\n', 'grey')
+  roots.print.log('(using ' + tmpl_name + ' template)\n', 'grey');
 };
 
 module.exports = { execute: _new };
@@ -57,6 +58,10 @@ function get_template(template_name){
   var config_dir = process.env.XDG_CONFIG_HOME || path.join(osenv.home() || tmp_dir, '.config');
   var tmpl_path = path.join(config_dir, 'roots/templates', name);
   var exists = fs.existsSync(tmpl_path);
+
+  // if the folder doesn't exist,
+  // make it before anything else happens
+  if (!exists) mkdirp.sync(tmpl_path);
 
   // if it's not in the global config, we don't have it
   if (!tmpl) return { error: 'template not found' };
@@ -98,12 +103,12 @@ function check_git_install(){
 }
 
 function update_git_repo(tmpl_path){
-  var pull_command = shell.exec('cd ' + tmpl_path + '; git pull', { silent: true });
+  var pull_command = shell.exec('cd ' + tmpl_path + '  && git pull', {silent: true});
 
   if (pull_command.code === 0) {
     return tmpl_path;
   } else {
-    return { error: pull_command.output }
+    return { error: pull_command.output };
   }
 }
 
@@ -113,6 +118,6 @@ function clone_git_repo(tmpl, tmpl_path){
   if (clone_command.code === 0) {
     return tmpl_path;
   } else {
-    return { error: clone_command.output }
+    return { error: clone_command.output };
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Make sure you have [node.js](http://nodejs.org/) installed, then just run `npm i
 * From Xcode go to Preferences -> Download -> Command Line Tools -> Install to install command line tools.
 
 ##### Windows Installs
-* If you encounter problems when installing. Please ensure [Git](http://git-scm.com/downloads), Python, and Visual C++ runtime executables are installed.
+* If you encounter problems when installing. Please ensure [Git](http://git-scm.com/downloads), Python 2.7, and Visual C++ runtime executables are installed.
 * You can install Windows Visual C++ components by doing any of the following: Installing Visual Studio 2005 or above, installing the .NET framework or manually adding it to your system PATH if it already exists on your machine.
 
 Usage


### PR DESCRIPTION
This is a fix for the 

```
fatal: could not create work tree dir 'C:\Users\Administrator\.config\roots\templates\default'.:No such file or directory
```

error message that users receive upon trying to create a new roots project on Windows machines.
The problem stems from a git issue and isn't present on other OSs.

Windows also has trouble with the `shell.exec` method using `;` to separate commands. That has been remedied in the `new` command also. 

I also fixed a few semicolon errors I saw with my linter. 

And last, but not least, I saw that [this](https://github.com/snowe2010/roots/blob/5079401595636304c5288c7e3057d8a0f0332f78/lib/commands/new.js#L84) line of code will never be hit, but I wasn't sure what to do about it. 

Closes #341 and #332 
