### PR TITLE
Added node_modules to watcher_ignores

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -58,7 +58,7 @@ class Config
     @watcher_ignores = @watcher_ignores.concat [
       'package.json',
       'app.coffee',
-      'node_modules',
+      'node_modules/**/*',
       "#{@output}/**/*"
     ]
 


### PR DESCRIPTION
Was causing 100% cpu usage when running `roots watch`.

https://github.com/jenius/roots/issues/407
