### PR TITLE
Added node_modules to watcher ignores

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -58,6 +58,7 @@ class Config
     @watcher_ignores = @watcher_ignores.concat [
       'package.json',
       'app.coffee',
+      'node_modules/**/*',
       "#{@output}/**/*"
     ]
 


### PR DESCRIPTION
Was causing 100% cpu usage when running `roots watch`.

https://github.com/jenius/roots/issues/407
