### PR TITLE
Fix "cannot find module '.new' " error on Windows

### DIFF
--- a/lib/cli/index.coffee
+++ b/lib/cli/index.coffee
@@ -45,7 +45,7 @@ class CLI extends EventEmitter
     if typeof args is 'string' then args = args.split(' ')
     args = @parser.parseArgs(args)
 
-    fn = require(".#{path.sep}#{args.fn}")
+    fn = require("./#{args.fn}")
     delete args.fn
 
     try p = fn(@, args)


### PR DESCRIPTION
This pull request is a start at an attempt to fix the "`Cannot find module './new'`" error in V3. The error was being caused by a malformed path being passed to `require`, due to there being a `path.sep` instance in the passed argument. `require` supposedly handles these cross platform inconsistencies itself, and I can confirm from months of experience that a simple forward slash (`/`) in `require` calls is a sufficient path separator on Windows.

This change gets rid of the error, and executes code. The new command still throws an unhandled rejection error, and that is due to Sprout - I will be submitting a PR there shortly.
