### PR TITLE
Changed when/node call to a simple function call

### DIFF
--- a/lib/api/compile.coffee
+++ b/lib/api/compile.coffee
@@ -101,9 +101,9 @@ class Compile
     if not hook then return W.resolve()
 
     if Array.isArray(hook)
-      hooks = hook.map((h) => nodefn.call(h.bind(@roots)))
+      hooks = hook.map((h) => h(@roots))
     else if typeof hook == 'function'
-      hooks = [nodefn.call(hook.bind(@roots))]
+      hooks = [hook(@roots)]
     else
       return W.reject('before hook should be a function or array')
 


### PR DESCRIPTION
This fixes #489 by calling the `before` and `after` configuration hooks normally and plugging their returned promise in `when.all()` if needed instead of using `when/node` which expects the hooks to call a passed callback function.

I'm guessing the `when/node` behaviour is not desired according to the docs.

This also fixes #488 where the roots object was passed to the hooks via `this` instead of the first argument.
