### PR TITLE
Fix Config#out extension regex replace

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -136,7 +136,7 @@ class Config
     if _.contains(@dump_dirs, res[0]) then res.shift()
     res.unshift(@output_path())
     res = res.join(path.sep)
-    if ext then res = res.replace(/\..*$/, ".#{ext}")
+    if ext then res = res.replace(///\.[^#{path.sep}]*$///, ".#{ext}")
     res
 
   ###*

--- a/test/compile.coffee
+++ b/test/compile.coffee
@@ -126,6 +126,14 @@ describe 'compile', ->
       path.join(output, 'folder.withdot/manyOf∫chin/er mer .gerd.wat').should.be.a.file()
       done()
 
+  it 'should compile correctly if any of the project\'s parent directories have a dot in their name', (done) ->
+    p = path.join(test_path, 'dir.with_dot')
+    output = path.join(p, 'public')
+
+    compile_fixture p, done, ->
+      path.join(output, 'manatoge.html').should.be.a.file()
+      done()
+
   it 'should work with different environments', (done) ->
     p = path.join(test_path, 'environments')
     output = path.join(p, 'public')

--- a/test/fixtures/compile/dir.with_dot/package.json
+++ b/test/fixtures/compile/dir.with_dot/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "devDependencies": {
+    "jade": "*"
+  }
+}

--- a/test/fixtures/compile/dir.with_dot/views/manatoge.jade
+++ b/test/fixtures/compile/dir.with_dot/views/manatoge.jade
@@ -1,0 +1,1 @@
+h1 fear the manatoge


### PR DESCRIPTION
This fixes an issue where roots gets too greedy when replacing the extension for paths that contain a `.` in the path name.

Previously, `/Users/josh/code/carrot.is/public/css/single/base/video.styl` was getting changed to `/Users/josh/code/carrot.css`.

The new regex ensures that roots only replaces after the last `.` character in the string. so `/Users/josh/code/carrot.is/public/css/single/base/video.styl` changes to `/Users/josh/code/carrot.is/public/css/single/base/video.css` as expected.

Also, I can definitely test this, but I was unsure the best place to put this, or whether this is tested at a higher level. Maybe somebody who's more familiar with the test suite structure can show me the best spot. I originally added it to the weird file names section (https://github.com/jenius/roots/blob/v3/test/compile.coffee#L113-L127), but that test fixture does not actually use any compilers, so no extensions are rewritten.

Closes #477 
