### PR TITLE
EMFILE error catching fix

### DIFF
--- a/lib/cli/watch.coffee
+++ b/lib/cli/watch.coffee
@@ -51,8 +51,10 @@ module.exports = (cli, args) ->
 ###
 
 on_error = (cli, server, active, err) ->
-  cli.emit('err', Error(err).stack)
-  if active then server.show_error(Error(err).stack)
+  err = Error(err)
+  if 'stack' in err then err = err.stack
+  cli.emit('err', err)
+  if active then server.show_error(err)
 
 ###*
  * When a change has been detected, notifies the cli and browser that a compile


### PR DESCRIPTION
Roots currently fails silently on an `EMFILE, too many open files` error.

When the `EMFILE` error gets wrapped into an `Error` object, it **does not** have the `stack` property. Not only that, when `.stack` is called on the error object, **everything breaks** and the entire program exits.

I can't even use `if err.stack then ...` here, because `.stack` causes roots to crash. The only workaround I was able to find was checking if the property existed with `if 'stack' in err ....`.
