### PR TITLE
add verbose mode

### DIFF
--- a/lib/cli/compile.coffee
+++ b/lib/cli/compile.coffee
@@ -8,10 +8,13 @@ Roots = require '../../lib'
  * @return {Promise} a promise for the compiled project
 ###
 
-module.exports = (cli, args)->
-  project = new Roots(args.path, { env: args.environment })
+module.exports = (cli, args) ->
+  project = new Roots args.path,
+    env: args.environment
+    verbose: args.verbose
 
   cli.emit('inline', 'compiling... '.grey)
+  if args.verbose then cli.emit('data', '')
 
   project.compile()
     .then -> cli.emit('data', 'done!'.green)

--- a/lib/cli/index.coffee
+++ b/lib/cli/index.coffee
@@ -136,6 +136,10 @@ class CLI extends EventEmitter
       defaultValue: 1111
       help: "Port you want to run the local server on (default 1111)"
 
+    s.addArgument ['--verbose', '-v'],
+      action: 'storeTrue'
+      help: "Offer more verbose output and compile stats"
+
     s.setDefaults(fn: 'watch')
 
   $compile = (sub) ->
@@ -150,6 +154,10 @@ class CLI extends EventEmitter
     s.addArgument ['--env', '-e'],
       defaultValue: process.env or 'development'
       help: "Your project's environment"
+
+    s.addArgument ['--verbose', '-v'],
+      action: 'storeTrue'
+      help: "Offer more verbose output and compile stats"
 
     s.setDefaults(fn: 'compile')
 

--- a/lib/cli/watch.coffee
+++ b/lib/cli/watch.coffee
@@ -19,12 +19,15 @@ Server = require '../local_server'
 ###
 
 module.exports = (cli, args) ->
-  project = new Roots(args.path, { env: args.environment })
+  project = new Roots args.path,
+    env: args.environment
+    verbose: args.verbose
+
   app  = new Server(project)
   port = process.env.port or args.port
   res = { project: project }
 
-  project.on('start', -> on_start(cli, app, res.server))
+  project.on('start', -> on_start(cli, app, res.server, project.config.verbose))
   project.on('done', -> on_done(cli, app, res.server))
   project.on('error', (err) -> on_error(cli, app, res.server, err))
 
@@ -65,8 +68,9 @@ on_error = (cli, server, active, err) ->
  * @param  {Object} server - server instance
 ###
 
-on_start = (cli, server, active) ->
+on_start = (cli, server, active, verbose) ->
   cli.emit('inline', 'compiling... '.grey)
+  if verbose then cli.emit('data', '')
   if active then server.compiling()
 
 ###*

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -41,6 +41,7 @@ class Config
     @output = 'public'
     @dump_dirs = ['views', 'assets']
     @env = opts.env ? 'development'
+    @verbose = opts.verbose ? false
     @debug = false
     @live_reload = true
     @open_browser = true

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -118,7 +118,8 @@ class Roots extends EventEmitter
 
   set_up_workers: ->
     @workers = [0...cpus].map =>
-      worker = cp.fork(path.join(__dirname, 'worker'), [@root, @opts])
+      args = [@root, JSON.stringify(@opts)]
+      worker = cp.fork(path.join(__dirname, 'worker'), args)
       worker.queue = []
       worker
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -22,7 +22,7 @@ var extensions = new Extensions(roots);
 roots.root = process.argv.slice(2)[0];
 roots.bail = _req('api/bail');
 roots.extensions = extensions;
-roots.config = new Config(roots, process.argv.slice(2)[1]);
+roots.config = new Config(roots, JSON.parse(process.argv.slice(2)[1]));
 
 //
 // message delegation
@@ -44,8 +44,13 @@ function compile(id, category, file){
   file = new File(file)
   if (!exts) exts = extensions.instantiate();
   if (!compiler) compiler = new Compiler(roots, exts);
+  var start = new Date;
 
   compiler.compile(category, file).done(function(){
+    // TODO: refactor this into promise/notify through cli events
+    if (roots.config.verbose) {
+      console.log(('▸ '+file.relative+': '+(new Date - start)+'ms').grey);
+    }
     process.send({ id: id, data: true });
   }, function(err){
     process.send({ id: id, data: err });


### PR DESCRIPTION
This also fixes an issue with options being passed through to workers. It does need to be tested. However, it is an awkward patch because I really don't want to take the time to set up the massive promise progress event passing flow required to properly test it at the moment, as it becomes even more painful passing back and forth between a bunch of worker processes. Probably this will just be accepted, then refactored later to include the progress event stuff and tested then.
