### PR TITLE
raise maximum number of open file descriptors to prevent EMFILE errors

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -3,6 +3,7 @@ fs     = require 'fs'
 accord = require 'accord'
 coffee = require 'coffee-script'
 _      = require 'lodash'
+posix  = require 'posix'
 
 ###*
  * @class Config
@@ -38,6 +39,9 @@ class Config
   ###
 
   constructor: (@roots, opts) ->
+    # raise maximum number of open file descriptors, prevents EMFILE errors
+    posix.setrlimit('nofile', { soft: process.env['ROOTS_RLIMIT'] || 10000 })
+
     @output = 'public'
     @dump_dirs = ['views', 'assets']
     @env = opts.env ? 'development'

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "sprout": "0.1.x",
     "update-notifier": "0.1.x",
     "vinyl": "0.2.x",
-    "when": "3.x"
+    "when": "3.x",
+    "posix": "1.0.x"
   },
   "devDependencies": {
     "chai": "*",

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,3 +1,5 @@
+posix = require 'posix'
+
 before (done) ->
   util.project.install_dependencies('*/*', done)
 
@@ -13,3 +15,10 @@ describe 'constructor', ->
     project = new Roots(path.join(base_path, 'compile/basic'))
     project.root.should.exist
     project.config.should.exist
+
+  describe 'open file limit', ->
+    before -> @limit = process.env['ROOTS_RLIMIT'] = 5000
+
+    it 'raises the limit according to the environment', ->
+      project = new Roots(path.join(base_path, 'compile/basic'))
+      posix.getrlimit('nofile').soft.should.equal(@limit)


### PR DESCRIPTION
Large roots project frequently fail to compile and raise the dreaded `Error: EMFILE, too many open files` error. This is due to the underlying OS setting a limit on the number of files any process can have open at simultaneously. On OSX, this number defaults to `256`, which is really low, especially since node modules tend to be a large number of very small files. Add in all the files we're watching and manipulating through roots and we hit this limit pretty quickly.

This raises the limit to a default of `10000` or a `ROOTS_RLIMIT` environment variable value. It persists through to the workers roots creates, and doesn't affect any other running processes.

I really don't know what the equivalent issue would be on a Windows machine, nor a good way to test this, but large sites like carrot.is do not compile without this fix. Also if someone can test that the `posix.setrlimit` call doesn't break on Windows that'd be great.
