### PR TITLE
add cli option to not use workers (for dynamic content compatibility)

### DIFF
--- a/lib/api/compile.coffee
+++ b/lib/api/compile.coffee
@@ -170,7 +170,12 @@ class Compile
     parallel = []
 
     compile_task = (cat) =>
-      W.map(ast[cat] ? [], @roots._queue.bind(@roots, cat))
+      compile_fn = if @roots.config.workers
+        @roots._queue.bind(@roots, cat)
+      else
+        @compiler.compile.bind(@compiler, cat)
+
+      W.map(ast[cat] ? [], compile_fn)
       .then(=> sequence(@extensions.hooks('category_hooks.after', cat), @, cat))
 
     for ext in @extensions

--- a/lib/cli/index.coffee
+++ b/lib/cli/index.coffee
@@ -131,6 +131,11 @@ class CLI extends EventEmitter
       help: "If present, this command will not automatically open a browser
       window"
 
+    s.addArgument ['--no-workers'],
+      action: 'storeTrue'
+      help: "If present, roots will not spawn any workers during compile
+      and instead use one single process"
+
     s.addArgument ['--port', '-p'],
       type: Number
       defaultValue: 1111
@@ -154,6 +159,11 @@ class CLI extends EventEmitter
     s.addArgument ['--env', '-e'],
       defaultValue: process.env or 'development'
       help: "Your project's environment"
+
+    s.addArgument ['--no-workers'],
+      action: 'storeTrue'
+      help: "If present, roots will not spawn any workers during compile
+      and instead use one single process"
 
     s.addArgument ['--verbose', '-v'],
       action: 'storeTrue'

--- a/lib/cli/watch.coffee
+++ b/lib/cli/watch.coffee
@@ -22,6 +22,7 @@ module.exports = (cli, args) ->
   project = new Roots args.path,
     env: args.environment
     verbose: args.verbose
+    workers: !args.no_workers
 
   app  = new Server(project)
   port = process.env.port or args.port

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -49,6 +49,7 @@ class Config
     @debug = false
     @live_reload = true
     @open_browser = true
+    @workers = opts.workers ? true
 
     load_config.call(@)
 

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -131,6 +131,26 @@ describe 'cli', ->
           done()
         , done
 
+    it 'should compile a project with --no-workers option', (done) ->
+      spy = sinon.spy()
+
+      cli.on('inline', spy)
+      cli.on('data', spy)
+
+      cwd = process.cwd()
+      process.chdir(path.join(__dirname, 'fixtures/compile/basic'))
+
+      cli.run('compile --no-workers')
+        .done ->
+          spy.should.have.been.calledTwice
+          spy.should.have.been.calledWith('compiling... '.grey)
+          spy.should.have.been.calledWith('done!'.green)
+          process.chdir(cwd)
+          cli.removeListener('inline', spy)
+          cli.removeListener('data', spy)
+          done()
+        , done
+
     it 'should compile a project at a given path', (done) ->
       spy = sinon.spy()
 


### PR DESCRIPTION
This adds a `--no-workers` option for `roots watch` and `roots compile` that forces roots to use one process instead of distributing across workers. This is for compatibility with the [dynamic-content](https://github.com/carrot/roots-dynamic-content) extension. Currently with workers enabled, multiple dynamic content files from one category are split between several workers. That means any workers who have to compile a view that lists all dynamic content in a category will be missing large amounts of content in the list because not all the files make it into the same worker.
