### PR TITLE
Fix Jade tests in preparation to version upgrade.

### DIFF
--- a/test/basic/views/layout.jade
+++ b/test/basic/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     meta(charset='utf8')
@@ -7,7 +7,7 @@ html
     meta(name='author', content= "author of the site")
 
     title welcome to roots!
-    
+
     link(rel='stylesheet', href='/css/example.css')
   body
     != content

--- a/test/basic_with_error/views/layout.jade
+++ b/test/basic_with_error/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     meta(charset='utf8')
@@ -7,7 +7,7 @@ html
     meta(name='author', content= "author of the site")
 
     title welcome to roots!
-    
+
   body
     != content
     != foo.bar.baz

--- a/test/compile_adapters/jade/views/layout.jade
+++ b/test/compile_adapters/jade/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title fat unicorns

--- a/test/dynamic_content/basic/layouts/_single.jade
+++ b/test/dynamic_content/basic/layouts/_single.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     meta(charset='utf8')
@@ -7,7 +7,7 @@ html
     meta(name='author', content= "author of the site")
 
     title= post.title
-    
+
     link(rel='stylesheet', href='/css/master.css')
   body
     h1= post.title

--- a/test/dynamic_content/basic/layouts/layout.jade
+++ b/test/dynamic_content/basic/layouts/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     meta(charset='utf8')
@@ -7,7 +7,7 @@ html
     meta(name='author', content= "author of the site")
 
     title welcome to roots!
-    
+
     link(rel='stylesheet', href='/css/master.css')
   body
     != content

--- a/test/dynamic_content/complex/layout.jade
+++ b/test/dynamic_content/complex/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title crazy complex dynamic content test

--- a/test/errors/views/layout.jade
+++ b/test/errors/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title errarrr!~

--- a/test/layouts/backtracked/views/layout.jade
+++ b/test/layouts/backtracked/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title backtracked roots layouts

--- a/test/layouts/cross-language/views/layout.jade
+++ b/test/layouts/cross-language/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title cross-language layout renders

--- a/test/stylus-warning-errors/views/layout.jade
+++ b/test/stylus-warning-errors/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
   body


### PR DESCRIPTION
Hi, I updated the Jade dependency to version `1.5.0`, as the previously used
version `0.35` was buggy.

For example, with the previous version, 

``` jade
// layout.jade
doctype html
head
  block title
    title layout
```

``` jade
block title
  title index
```

would yield `<title>layout</title>` instead of `<title>index</title>`.
This is fixed with the version update.

As `!!!` has been deprecrated, I replaced it by `doctype html` in Jade templates.
