### PR TITLE
set hard rlimit as well to prevent crash on linux

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -40,9 +40,8 @@ class Config
 
   constructor: (@roots, opts) ->
     # raise maximum number of open file descriptors, prevents EMFILE errors
-    # switching to graceful-fs in accord should remove the need for this hack,
-    # also this fails on linux so it's wrapped in a `try`
-    try posix.setrlimit('nofile', soft: process.env['ROOTS_RLIMIT'] || 10000)
+    limit = process.env['ROOTS_RLIMIT'] || 10000
+    try posix.setrlimit('nofile', { soft: limit, hard: limit })
 
     @output = 'public'
     @dump_dirs = ['views', 'assets']


### PR DESCRIPTION
Compile crashes on Linux machines if the [soft rlimit is greater than the hard limit](http://stackoverflow.com/questions/19017658/node-posix-setrlimit-crashes-einval-invalid-argument).
