### PR TITLE
uncomment environment test assertions

### DIFF
--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -381,7 +381,7 @@ describe 'cli', ->
       p   = path.join(__dirname, 'fixtures/compile/environments')
       @cli.run("compile #{p} --env #{env}")
         .done =>
-          # @spy.args[0][1].env.should.equal(env)
+          @spy.args[0][1].env.should.equal(env)
           done()
 
     it 'watch should handle environments args correctly', (done) ->
@@ -390,5 +390,5 @@ describe 'cli', ->
       @cli.run("watch #{p} --env #{env} --no-open")
         .catch(->)
         .done =>
-          # @spy.args[0][1].env.should.equal(env)
+          @spy.args[0][1].env.should.equal(env)
           done()


### PR DESCRIPTION
hah @jenius, you fixed the roots environment tests, but you forgot to uncomment the actual assertions themselves. this still passes though :tada:.
