### PR TITLE
allow open_browser to take a uri/app option

### DIFF
--- a/lib/cli/watch.coffee
+++ b/lib/cli/watch.coffee
@@ -41,7 +41,10 @@ module.exports = (cli, args) ->
       res.watcher = w
       res.server = app.start(port)
       if project.config.open_browser and not args.no_open
-        open("http://localhost:#{port}/")
+        if project.config.open_browser == true
+          open("http://localhost:#{port}/")
+        else
+          open(project.config.open_browser)
     .yield(res)
 
 ###*


### PR DESCRIPTION
now the `open_browser` option in your `app.coffee` can trigger a different url (or anything that can be passed to the `open()` unix command. 

tests & doc updates are forthcoming