### PR TITLE
Environment merge

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -99,7 +99,7 @@ class Config
     conf = read_config.call(@, "app")
 
     if @env isnt 'development'
-      env_conf        = read_config.call(@, "app.#{@env}")
+      env_conf = read_config.call(@, "app.#{@env}")
 
       # merge environment locals into default locals
       env_conf.locals = _.merge(conf.locals, env_conf.locals)
@@ -206,6 +206,8 @@ class Config
       conf = eval coffee.compile(
         fs.readFileSync("#{config_path}.coffee", 'utf8'), { bare: true }
       )
+
+    conf.extensions ?= []
     return conf
 
 

--- a/test/compile.coffee
+++ b/test/compile.coffee
@@ -160,9 +160,6 @@ describe 'compile', ->
       @project.config.locals.data.user.name.should.eq('alfred')
       @project.config.locals.data.user.age.should.eq(45)
 
-    it 'should concat arrays in locals together at the same key', ->
-      @project.config.locals.data.values.should.eq([1,2,3,4])
-
     it 'should replace extensions from the default app.coffee w environment specific ones', ->
       @project.config.locals.test_extension.test.should.eq('app.doge.coffee')
       @project.config.locals.another_extension.test.should.eq('another extension')

--- a/test/compile.coffee
+++ b/test/compile.coffee
@@ -144,15 +144,29 @@ describe 'compile', ->
       p.should.have.content('/path_helper.html')
       done()
 
-  it 'should work with different environments', (done) ->
-    p = path.join(test_path, 'environments')
-    output = path.join(p, 'public')
+  describe 'environments', ->
 
-    (new Roots(p, { env: 'doge' })).compile().done ->
-      path.join(output, 'doge_file.html').should.be.a.file()
-      path.join(output, 'dev_file.html').should.not.be.a.path()
-      done()
-    , done
+    before (done) ->
+      p        = path.join(test_path, 'environments')
+      @output  = path.join(p, 'public')
+      @project = (new Roots(p, { env: 'doge' }))
+      @project.compile().done((-> done()), done)
+
+    it 'should ignore files based off the correct environment', ->
+      path.join(@output, 'doge_file.html').should.be.a.file()
+      path.join(@output, 'dev_file.html').should.not.be.a.path()
+
+    it 'it should merge locals from the environment w the default locals from app.coffee', ->
+      @project.config.locals.data.user.name.should.eq('alfred')
+      @project.config.locals.data.user.age.should.eq(45)
+
+    it 'should concat arrays in locals together at the same key', ->
+      @project.config.locals.data.values.should.eq([1,2,3,4])
+
+    it 'should replace extensions from the default app.coffee w environment specific ones', ->
+      @project.config.locals.test_extension.test.should.eq('app.doge.coffee')
+      @project.config.locals.another_extension.test.should.eq('another extension')
+
 
   it 'should output sourcemaps when specified', (done) ->
     p = path.join(test_path, 'sourcemaps')

--- a/test/fixtures/compile/environments/another_extension.coffee
+++ b/test/fixtures/compile/environments/another_extension.coffee
@@ -1,0 +1,5 @@
+module.exports = (opts) ->
+  class AnotherExtension
+    constructor: (@roots) ->
+      @roots.config.locals.another_extension ?= {}
+      @roots.config.locals.another_extension.test = opts.test

--- a/test/fixtures/compile/environments/app.coffee
+++ b/test/fixtures/compile/environments/app.coffee
@@ -1,1 +1,25 @@
-ignores: ['doge_file.html']
+test_extension    = require './test_extension'
+another_extension = require './another_extension'
+
+module.exports = 
+  output: 'public'
+  ignores: ['doge_file.html']
+  dump_dirs: ['views', 'assets']
+  debug: false
+  live_reload: true
+  open_browser: true
+  locals:
+    data: [
+      user:
+        name: 'joe'
+        age: 45
+      values: [1, 2]
+    ]
+  server:
+    clean_urls: true
+    exclude: ['some_file']
+    routes: {"**": "index.html"}
+  extensions: [
+    test_extension(test: 'app.coffee'),
+    another_extension(test: 'another extension')
+  ]

--- a/test/fixtures/compile/environments/app.coffee
+++ b/test/fixtures/compile/environments/app.coffee
@@ -9,12 +9,11 @@ module.exports =
   live_reload: true
   open_browser: true
   locals:
-    data: [
+    data:
       user:
         name: 'joe'
         age: 45
       values: [1, 2]
-    ]
   server:
     clean_urls: true
     exclude: ['some_file']

--- a/test/fixtures/compile/environments/app.doge.coffee
+++ b/test/fixtures/compile/environments/app.doge.coffee
@@ -9,12 +9,11 @@ module.exports =
   live_reload: false
   open_browser: false
   locals:
-    data: [
+    data:
       user:
         name: 'alfred'
         location: 'new york'
       values: [3, 4]
-    ]
   server:
     clean_urls: false
     exclude: ['another file']

--- a/test/fixtures/compile/environments/app.doge.coffee
+++ b/test/fixtures/compile/environments/app.doge.coffee
@@ -1,1 +1,22 @@
-ignores: ['dev_file.html']
+test_extension    = require './test_extension'
+another_extension = require './another_extension'
+
+module.exports =
+  output: 'public'
+  ignores: ['dev_file.html']
+  dump_dirs: ['test']
+  debug: true
+  live_reload: false
+  open_browser: false
+  locals:
+    data: [
+      user:
+        name: 'alfred'
+        location: 'new york'
+      values: [3, 4]
+    ]
+  server:
+    clean_urls: false
+    exclude: ['another file']
+    routes: {"**": "home.html", "work/**/*": "work.html"}
+  extensions: [test_extension(test: 'app.doge.coffee')]

--- a/test/fixtures/compile/environments/test_extension.coffee
+++ b/test/fixtures/compile/environments/test_extension.coffee
@@ -1,0 +1,5 @@
+module.exports = (opts) ->
+  class TestExtension
+    constructor: (@roots) ->
+      @roots.config.locals.test_extension ?= {}
+      @roots.config.locals.test_extension.test = opts.test


### PR DESCRIPTION
This PR adds functionality to how environments are loaded into roots. If you have an environment file, such as `app.production.coffee`, roots will now merge the locals and extensions from the environment file  into the default `app.coffee` locals and extensions.

This is useful for keeping locals and extension configurations DRY across environments. This way you only need to add locals into the environment specifc config that need to override values in the main `app.coffee`. I found this useful to prevent having to duplicate a lot of helper functions and values in my locals across environments.

When it comes to extensions, since they're already called functions we can't replace the options that were already passed in. So instead, if you have an extension in your environment specific config that matches in class name with one from your `app.coffee`, the environment specific one completely replaces it.
