### PR TITLE
Switched to use when/node .lift to ensure functions listen to promises

### DIFF
--- a/lib/api/compile.coffee
+++ b/lib/api/compile.coffee
@@ -104,9 +104,9 @@ class Compile
     if not hook then return W.resolve()
 
     if Array.isArray(hook)
-      hooks = hook.map((h) => nodefn.call(_.partial(h, @roots)))
+      hooks = hook.map((h) => nodefn.lift(_.partial(h, @roots).call(@roots)))
     else if typeof hook is 'function'
-      hooks = [nodefn.call(_.partial(hook, @roots))]
+      hooks = [nodefn.lift(_.partial(hook, @roots).call(@roots))]
     else
       return W.reject('before hook should be a function or array')
 


### PR DESCRIPTION
Switched to use when/node .lift to ensure functions listen to promises returned by hook functions.

This enables us to specify async promise-based 'before' hook functions which should finish before compilation starts.