### PR TITLE
Fix for "Not Working In Windows #588"

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -11,6 +11,13 @@ os     = require('os')
 ###
 
 class Config
+  ###*
+   * This is an escaped version of the platform specific path seperator to be
+   * used in regular expressions. It is defined as a (derived) constant,
+   * because the path seperator does not change over the course of a run.
+  ###
+  
+  PATH_SEPERATOR_REGEXP_STRING = path.sep.replace '\\', '\\\\'
 
   ###*
    * Creates a new instance of the roots config. This happens once, as soon as
@@ -141,10 +148,7 @@ class Config
     res.unshift(@output_path())
     res = res.join(path.sep)
     if ext
-      if (os.platform() is 'win32')
-        res = res.replace(///\.[^\#{path.sep}]*$///, ".#{ext}")
-      else
-        res = res.replace(///\.[^#{path.sep}]*$///, ".#{ext}")
+      res = res.replace(///\.[^#{PATH_SEPERATOR_REGEXP_STRING}]*$///, ".#{ext}")
     res
 
   ###*

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "test": "npm run lint && mocha",
-    "lint": "find lib/ -name '*.coffee' | xargs coffeelint",
+    "lint": "coffeelint lib",
     "coverage": "make build; istanbul cover _mocha --report html -- -R spec && open coverage/index.html && make unbuild",
     "coveralls": "make build; istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage; make unbuild",
     "postinstall": "node ./post_install.js"


### PR DESCRIPTION
This is a fix as discussed in [https://github.com/jenius/roots/issues/588](https://github.com/jenius/roots/issues/588).

There are still some issues with the tests and coverage running on Windows. These issues are not impairing the functionality of this fix. All tests are green except the after hook described below.

Tests: After hook from [https://github.com/jenius/roots/blob/master/test/index.coffee](https://github.com/jenius/roots/blob/master/test/index.coffee) is not working.
```
  1)  "after all" hook:
     Error: ENOTEMPTY, directory not empty 'C:\Users\dittrich\Documents\roots\test\fixtures\compile\hooks\public'
    at Object.fs.rmdirSync (fs.js:612:18)
    at rmkidsSync (C:\Users\dittrich\Documents\roots\node_modules\rimraf\rimraf.js:328:11)
    at rmdirSync (C:\Users\dittrich\Documents\roots\node_modules\rimraf\rimraf.js:318:7)
    at Function.rimrafSync [as sync] (C:\Users\dittrich\Documents\roots\node_modules\rimraf\rimraf.js:289:9)
    at Context.<anonymous> (C:\Users\dittrich\Documents\roots\test\index.coffee:9:10)
    at Hook.Runnable.run (C:\Users\dittrich\AppData\Roaming\npm\node_modules\mocha\lib\runnable.js:217:15)
    at next (C:\Users\dittrich\AppData\Roaming\npm\node_modules\mocha\lib\runner.js:258:10)
    at Object._onImmediate (C:\Users\dittrich\AppData\Roaming\npm\node_modules\mocha\lib\runner.js:275:5)
    at processImmediate [as _immediateCallback] (timers.js:330:15)
```
Coverage: Istanbul seems to have some issues with the parameters on Windows. I'm not sure how to fix this and currently don't have time to investigate further.
```
C:\Users\dittrich\Documents\roots>npm run coverage

> roots@3.0.2 coverage C:\Users\dittrich\Documents\roots
> make build && istanbul cover _mocha --report html -- -R spec && open coverage/index.html && make unbuild

cp -R lib src
coffee -c lib

C:\Users\dittrich\Documents\roots\node_modules\.bin\_mocha.CMD:1
(function (exports, require, module, __filename, __dirname) { @IF EXIST "%~dp0
                                                              ^
No coverage information was collected, exit without writing coverage information
SyntaxError: Unexpected token ILLEGAL
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Object.Module._extensions.(anonymous function) [as .js] (C:\Users\dittrich\Documents\roots\node_modules\istanbul\
lib\hook.js:107:37)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at runFn (C:\Users\dittrich\Documents\roots\node_modules\istanbul\lib\command\common\run-with-cover.js:122:16)
    at C:\Users\dittrich\Documents\roots\node_modules\istanbul\lib\command\common\run-with-cover.js:248:17
    at C:\Users\dittrich\Documents\roots\node_modules\istanbul\lib\util\file-matcher.js:68:16
    at C:\Users\dittrich\Documents\roots\node_modules\istanbul\node_modules\async\lib\async.js:254:17

npm ERR! roots@3.0.2 coverage: `make build && istanbul cover _mocha --report html -- -R spec && open coverage/index.html
 && make unbuild`
npm ERR! Exit status 8
npm ERR!
npm ERR! Failed at the roots@3.0.2 coverage script.
npm ERR! This is most likely a problem with the roots package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     make build && istanbul cover _mocha --report html -- -R spec && open coverage/index.html && make unbuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls roots
npm ERR! There is likely additional logging output above.
npm ERR! System Windows_NT 6.2.9200
npm ERR! command "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js"
 "run" "coverage"
npm ERR! cwd C:\Users\dittrich\Documents\roots
npm ERR! node -v v0.10.26
npm ERR! npm -v 1.4.3
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     C:\Users\dittrich\Documents\roots\npm-debug.log
npm ERR! not ok code 0
```