### PR TITLE
Avoiding global options mutation

### DIFF
--- a/lib/compiler.coffee
+++ b/lib/compiler.coffee
@@ -370,7 +370,7 @@ class CompilePass
     file_options    = @file.file_options
     compile_options = @file.compile_options
 
-    _.extend(global_options, adapter_options, file_options, compile_options)
+    _.extend({}, global_options, adapter_options, file_options, compile_options)
 
   ###*
    * As small of a function as this is, it's the one that actually is doing


### PR DESCRIPTION
This aims to fix the issue mentioned by @Gioni06 within issue #640.

I was experiencing the same issue, whereby `roots compile` would work every time, but the `roots watch` command would only work reliably the first time, and then rarely on subsequent changes.

The kind of error message I would see was:

![enoent](https://cloud.githubusercontent.com/assets/104673/9219862/57ec912c-4121-11e5-9c00-626daef8010d.jpg)

I tracked the error down to the occurrence of a `filename` option being supplied to roots-records, and then on to the Jade compiler on subsequent builds. The value would override the auto-determination of the `filename` by Jade, and subsequently cause the crash as Jade uses the `filename` property to determine the location of relative path based extends/includes.

The offending `filename` value turned out to be getting injected into the `roots.config.locals` (and repeatedly overwritten) during the `configure_options` call, and it's the unpredictable nature of the last file to pass through `configure_options` that causes the error to point to various locations.

I've run the supplied tests and it *seems* Roots does not need the `roots.config.locals` to be mutated during the compile, so this should be a viable fix.