### PR TITLE
default arg to production on deploy

### DIFF
--- a/lib/cli/deploy.coffee
+++ b/lib/cli/deploy.coffee
@@ -15,7 +15,6 @@ module.exports = (cli, args) ->
 
   if !args.env and fs.existsSync(path.join(args.path, 'app.production.coffee'))
     args.env = 'production'
-  delete args.env
 
   project = new Roots args.path, env: args.env
 


### PR DESCRIPTION
Not sure why ```delete args.env``` was being called here. Perhaps @nporteschaikin can shed some light here.

Related issue: https://github.com/jenius/roots/issues/676