### PR TITLE
Supporting envs other than development/production

### DIFF
--- a/lib/api/deploy.coffee
+++ b/lib/api/deploy.coffee
@@ -13,8 +13,9 @@ class Deploy
     @project.clean()
     .then => @project.compile()
     .then =>
-      if fs.existsSync(path.join(@project.root, 'ship.production.conf'))
-        new Ship(root: @project.root, deployer: opts.to, env: 'production')
+      env = @project.config.env
+      if fs.existsSync(path.join(@project.root, "ship.#{env}.conf"))
+        new Ship(root: @project.root, deployer: opts.to, env: env)
       else
         new Ship(root: @project.root, deployer: opts.to)
     .tap (ship) ->

--- a/test/deploy.coffee
+++ b/test/deploy.coffee
@@ -55,3 +55,17 @@ describe 'deploy', ->
     .then -> path.join(p, 'public/index.html').should.have.content('foo')
     .catch(console.log)
     .should.be.fulfilled
+
+  it 'deploys with another environment if available', ->
+    p = path.join(base_path, 'deploy/another_environment')
+    project = new Roots(p, env: 'foo')
+    stubs = [
+      sinon.stub(fs, 'existsSync').returns(true)
+      sinon.stub(fs, 'readFileSync').returns('nowhere:\n  nothing: wow')
+    ]
+
+    project.deploy(to: 'nowhere')
+    .catch(console.log)
+    .then (ship) -> ship.env.should.eql('foo')
+    .should.be.fulfilled
+    .then -> stubs.forEach((stub) -> stub.restore())


### PR DESCRIPTION
Hi Carrot,

First of all, thanks for the great resource. I wanted to keep my static site generation purely in node-land and so far, Roots is delivering.

I encountered an issue when running the command:

```
roots deploy --env qa -to s3
```

ship already has support for arbitrary environment names, as does roots itself, so I figured that that command not working is actually a bug/missing feature. This PR adds this feature- feedback welcome!