### PR TITLE
Ignore all files starting with `.git`

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -61,7 +61,7 @@ class Config
       'package.json',
       'app*.coffee',
       "#{@output}/**/*",
-      '.git'
+      '.git*'
     ]
 
     @watcher_ignores ?= []
@@ -70,7 +70,7 @@ class Config
       'app.coffee',
       'node_modules/**/*',
       "#{@output}/**/*",
-      '.git'
+      '.git*'
     ]
 
     @compilers = get_compilers.call(@)


### PR DESCRIPTION
Let watcher and compiler automatically ignore all files and folders starting with `.git` (not just the `.git` folder). This fixes an infinite compilation loop issue when running `roots watch` on Windows with Visual Studio Code open => watcher was detecting changes to `.gitignore` every few seconds.